### PR TITLE
feat: expose per-cell OSC 8 hyperlink via surface API

### DIFF
--- a/Sources/libghosttyx/Views/TerminalView.swift
+++ b/Sources/libghosttyx/Views/TerminalView.swift
@@ -61,6 +61,9 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
     /// Current working directory.
     public private(set) var workingDirectory: String?
 
+    /// The OSC 8 hyperlink URL currently under the mouse cursor, or nil.
+    public private(set) var currentHoverLink: String?
+
     /// Marked text for IME composition.
     private var markedTextStorage: NSMutableAttributedString = .init()
     private var _markedRange: NSRange = .init(location: NSNotFound, length: 0)
@@ -672,6 +675,10 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
 
         case .desktopNotification(let title, let body):
             delegate?.desktopNotification(source: self, title: title, body: body)
+
+        case .mouseOverLink(let url):
+            currentHoverLink = url
+            delegate?.mouseOverLink(source: self, url: url)
 
         default:
             break

--- a/Sources/libghosttyx/Views/TerminalViewDelegate.swift
+++ b/Sources/libghosttyx/Views/TerminalViewDelegate.swift
@@ -27,6 +27,10 @@ public protocol TerminalViewDelegate: AnyObject {
     /// Called when the terminal requests opening a URL.
     func requestOpenLink(source: TerminalView, url: URL)
 
+    /// Called when the mouse hovers over or leaves an OSC 8 hyperlink.
+    /// - Parameter url: The hyperlink URI, or nil when the mouse leaves the link.
+    func mouseOverLink(source: TerminalView, url: String?)
+
     /// Called when the terminal's child process exits.
     func processExited(source: TerminalView, exitCode: UInt32, runtimeMs: UInt64)
 
@@ -55,6 +59,7 @@ public extension TerminalViewDelegate {
     func requestOpenLink(source: TerminalView, url: URL) {
         NSWorkspace.shared.open(url)
     }
+    func mouseOverLink(source: TerminalView, url: String?) {}
     func processExited(source: TerminalView, exitCode: UInt32, runtimeMs: UInt64) {}
     func surfaceClosed(source: TerminalView, processAlive: Bool) {}
     func desktopNotification(source: TerminalView, title: String, body: String) {}


### PR DESCRIPTION
## Summary

- Wire up the existing `MOUSE_OVER_LINK` action (previously silently dropped in `handleAction`'s `default: break`) to a new delegate method and tracked property
- Add `mouseOverLink(source:url:)` to `TerminalViewDelegate` with a default no-op implementation
- Add `currentHoverLink` public property to `TerminalView` so embedders can check hover state at click time

## How it works

When the mouse hovers over an OSC 8 hyperlinked cell, Ghostty fires `MOUSE_OVER_LINK` with the URL. This was already being parsed into `.mouseOverLink(url)` by `GhosttyAction` but silently dropped. Now it:
1. Stores the URL in `currentHoverLink`
2. Notifies the delegate via `mouseOverLink(source:url:)`
3. Clears both when the mouse leaves the link (`url: nil`)

## Test plan

- [x] `swift build` compiles cleanly
- [x] `swift test` — all 6 existing tests pass
- [ ] Manual: `printf '\e]8;;https://example.com\e\\click here\e]8;;\e\\'` — hover over "click here" and verify delegate callback fires

Closes #3