### PR TITLE
feat: add public close() method for deterministic teardown

### DIFF
--- a/Sources/libghosttyx/Views/TerminalView.swift
+++ b/Sources/libghosttyx/Views/TerminalView.swift
@@ -106,13 +106,44 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
     }
 
     deinit {
+        // Capture locals before any writes so we don't touch main-actor
+        // state from the nonisolated deinit context.
         if let link = displayLink {
             CVDisplayLinkStop(link)
         }
-        // Release the retained WeakBox that was passed to CVDisplayLink.
         if let ptr = displayLinkBoxPtr {
             Unmanaged<WeakBox<TerminalView>>.fromOpaque(ptr).release()
         }
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Teardown
+
+    /// Stops rendering, releases the ghostty surface, and detaches from
+    /// notification observers.
+    ///
+    /// Use this when embedding the view in a container (e.g. SwiftUI
+    /// `NSViewRepresentable`) that may keep the view alive longer than
+    /// you need it — for example, `WindowGroup` retains scene state for
+    /// tabbed windows even after the tab closes. Calling `close()` frees
+    /// the expensive resources (display link, Metal surface, PTY) even if
+    /// the NSView itself is still reachable from the outer view tree.
+    ///
+    /// Safe to call multiple times. After calling `close()`, the view
+    /// cannot be restarted — create a new instance instead.
+    public func close() {
+        if let link = displayLink {
+            CVDisplayLinkStop(link)
+            self.displayLink = nil
+        }
+        if let ptr = displayLinkBoxPtr {
+            Unmanaged<WeakBox<TerminalView>>.fromOpaque(ptr).release()
+            self.displayLinkBoxPtr = nil
+        }
+        // Dropping the surface runs GhosttySurface.deinit which calls
+        // ghostty_surface_free, releasing the PTY, renderer, and child
+        // process group.
+        self.surface = nil
         NotificationCenter.default.removeObserver(self)
     }
 


### PR DESCRIPTION
## Summary

- Adds a public `close()` method to `TerminalView` that releases the `CVDisplayLink`, ghostty surface, and PTY without waiting for `deinit`.
- Splits teardown so the nonisolated `deinit` only reads main-actor state (safety net) while `close()` performs the writes on the main actor.

## Motivation

SwiftUI `WindowGroup` retains scene state for tabbed windows — when a tab closes, `NSViewRepresentable.dismantleNSView` does not fire and the `TerminalView` stays alive in the scene tree. That means the `CVDisplayLink` keeps running at ~60Hz, the Metal surface stays on the GPU, and the PTY / child process remain open. Over a session of opening and closing tabs, this adds up to noticeable CPU burn and leaked processes.

With `close()`, a container can deterministically release those resources on `NSWindow.willCloseNotification` even when AppKit/SwiftUI still holds the view reference. The view object itself becomes an inert husk (a few hundred bytes) rather than a ~60Hz rendering loop.

## Test plan

- [x] Validated in downstream consumer (cortina): after closing 3 of 4 tabs, thread sample shows display-link threads drop 4→1, renderer threads 2→1, io threads 3→1, and 3/3 ghostty surfaces + PTYs are freed.
- [x] `close()` is idempotent — safe to call from multiple teardown paths.
- [ ] CI build passes