### PR TITLE
fix: handle 6 previously silently-dropped action types (closes #6)

### DIFF
--- a/Sources/libghosttyx/Core/GhosttyCallbackBridge.swift
+++ b/Sources/libghosttyx/Core/GhosttyCallbackBridge.swift
@@ -187,14 +187,19 @@ enum GhosttyCallbackBridge {
         guard let userdata = userdata else { return }
         let view = Unmanaged<TerminalView>.fromOpaque(userdata).takeUnretainedValue()
 
-        DispatchQueue.main.async {
-            // For now, auto-confirm. Host apps can customize via delegate.
-            let content = NSPasteboard.general.string(forType: .string)
-            view.surface?.completeClipboardRequest(
-                data: content,
-                state: statePtr,
-                confirmed: true
-            )
+        // Complete synchronously on the main thread — statePtr is only valid
+        // during this callback invocation, so async dispatch risks a dangling pointer
+        // if the surface is freed before the block executes.
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                let content = NSPasteboard.general.string(forType: .string)
+                view.surface?.completeClipboardRequest(data: content, state: statePtr, confirmed: true)
+            }
+        } else {
+            DispatchQueue.main.async {
+                let content = NSPasteboard.general.string(forType: .string)
+                view.surface?.completeClipboardRequest(data: content, state: statePtr, confirmed: true)
+            }
         }
     }
 

--- a/Sources/libghosttyx/Views/TerminalView.swift
+++ b/Sources/libghosttyx/Views/TerminalView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import libghostty
+import os
 
 /// An NSView that hosts a ghostty terminal surface.
 ///
@@ -809,7 +810,30 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
       currentHoverLink = url
       delegate?.mouseOverLink(source: self, url: url)
 
+    case .mouseVisibility(let visibility):
+      let visible = visibility == GHOSTTY_MOUSE_VISIBLE
+      if visible { NSCursor.unhide() } else { NSCursor.hide() }
+      delegate?.mouseVisibilityChanged(source: self, visible: visible)
+
+    case .secureInput(let state):
+      delegate?.secureInputChanged(source: self, enabled: state == GHOSTTY_SECURE_INPUT_ON)
+
+    case .sizeLimit(let minW, let minH, let maxW, let maxH):
+      delegate?.sizeLimitChanged(source: self, minCols: minW, minRows: minH, maxCols: maxW, maxRows: maxH)
+
+    case .initialSize(let w, let h):
+      delegate?.initialSizeRequested(source: self, cols: w, rows: h)
+
+    case .progressReport(let state, let progress):
+      delegate?.progressReported(source: self, state: state, progress: progress)
+
+    case .rendererHealth(let health):
+      delegate?.rendererHealthChanged(source: self, health: health)
+
     default:
+      #if DEBUG
+      os_log(.debug, "TerminalView: unhandled action %{public}@", String(describing: action))
+      #endif
       break
     }
   }

--- a/Sources/libghosttyx/Views/TerminalView.swift
+++ b/Sources/libghosttyx/Views/TerminalView.swift
@@ -35,7 +35,7 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
 
   /// Returns the text content of a single viewport row (0-indexed from top).
   public func readLineText(row: Int) -> String? {
-    guard let size = surface?.size else { return nil }
+    guard row >= 0, let size = surface?.size, row < Int(size.rows) else { return nil }
     let sel = ghostty_selection_s(
       top_left: ghostty_point_s(
         tag: GHOSTTY_POINT_VIEWPORT, coord: GHOSTTY_POINT_COORD_EXACT, x: 0, y: UInt32(row)),
@@ -322,6 +322,14 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
 
   open override func viewDidMoveToWindow() {
     super.viewDidMoveToWindow()
+
+    // Remove any previously registered window-specific observers before
+    // re-registering for the new window, preventing duplicate callbacks
+    // when the view moves between windows.
+    NotificationCenter.default.removeObserver(
+      self, name: NSWindow.didChangeBackingPropertiesNotification, object: nil)
+    NotificationCenter.default.removeObserver(
+      self, name: NSWindow.didChangeOcclusionStateNotification, object: nil)
 
     if window == nil {
       // NSCursor.hide() is process-wide and reference-counted with no automatic

--- a/Sources/libghosttyx/Views/TerminalView.swift
+++ b/Sources/libghosttyx/Views/TerminalView.swift
@@ -323,7 +323,12 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
   open override func viewDidMoveToWindow() {
     super.viewDidMoveToWindow()
 
-    if let window = window {
+    if window == nil {
+      // NSCursor.hide() is process-wide and reference-counted with no automatic
+      // reset. Unhide here so a hidden cursor doesn't persist for the entire app
+      // after this view leaves the window.
+      NSCursor.unhide()
+    } else if let window = window {
       surface?.setContentScale(window.backingScaleFactor)
       updateSurfaceSize()
       updateDisplayID()
@@ -816,13 +821,14 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
       delegate?.mouseVisibilityChanged(source: self, visible: visible)
 
     case .secureInput(let state):
+      // TOGGLE is an app-level action; at surface level only ON/OFF are expected.
       delegate?.secureInputChanged(source: self, enabled: state == GHOSTTY_SECURE_INPUT_ON)
 
-    case .sizeLimit(let minW, let minH, let maxW, let maxH):
-      delegate?.sizeLimitChanged(source: self, minCols: minW, minRows: minH, maxCols: maxW, maxRows: maxH)
+    case .sizeLimit(let minWidth, let minHeight, let maxWidth, let maxHeight):
+      delegate?.sizeLimitChanged(source: self, minCols: minWidth, minRows: minHeight, maxCols: maxWidth, maxRows: maxHeight)
 
-    case .initialSize(let w, let h):
-      delegate?.initialSizeRequested(source: self, cols: w, rows: h)
+    case .initialSize(let width, let height):
+      delegate?.initialSizeRequested(source: self, cols: width, rows: height)
 
     case .progressReport(let state, let progress):
       delegate?.progressReported(source: self, state: state, progress: progress)

--- a/Sources/libghosttyx/Views/TerminalView.swift
+++ b/Sources/libghosttyx/Views/TerminalView.swift
@@ -486,16 +486,15 @@ open class TerminalView: NSView, @preconcurrency NSTextInputClient {
     key_ev.composing = composing
 
     // Only send text if it's not a control character (ghostty handles those internally)
-    var result = false
     if let text, !text.isEmpty,
       let codepoint = text.utf8.first, codepoint >= 0x20
     {
       text.withCString { ptr in
         key_ev.text = ptr
-        result = surface.sendKey(key_ev)
+        surface.sendKey(key_ev)
       }
     } else {
-      result = surface.sendKey(key_ev)
+      surface.sendKey(key_ev)
     }
 
   }

--- a/Sources/libghosttyx/Views/TerminalViewDelegate.swift
+++ b/Sources/libghosttyx/Views/TerminalViewDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import libghostty
 
 /// Protocol for receiving callbacks from a `TerminalView`.
 ///
@@ -48,6 +49,24 @@ public protocol TerminalViewDelegate: AnyObject {
 
     /// Called when the terminal color scheme changes.
     func colorChanged(source: TerminalView, kind: Int, r: UInt8, g: UInt8, b: UInt8)
+
+    /// Called when the terminal requests the mouse cursor be shown or hidden.
+    func mouseVisibilityChanged(source: TerminalView, visible: Bool)
+
+    /// Called when secure input mode changes (e.g. a password prompt via sudo).
+    func secureInputChanged(source: TerminalView, enabled: Bool)
+
+    /// Called when Ghostty sets size constraints for the terminal.
+    func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32)
+
+    /// Called when Ghostty requests an initial terminal size.
+    func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32)
+
+    /// Called when a foreground command reports progress.
+    func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8)
+
+    /// Called when the GPU renderer health changes.
+    func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e)
 }
 
 // MARK: - Default Implementations
@@ -69,4 +88,10 @@ public extension TerminalViewDelegate {
     func desktopNotification(source: TerminalView, title: String, body: String) {}
     func mouseShapeChanged(source: TerminalView, shape: Int) {}
     func colorChanged(source: TerminalView, kind: Int, r: UInt8, g: UInt8, b: UInt8) {}
+    func mouseVisibilityChanged(source: TerminalView, visible: Bool) {}
+    func secureInputChanged(source: TerminalView, enabled: Bool) {}
+    func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32) {}
+    func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32) {}
+    func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8) {}
+    func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e) {}
 }

--- a/Tests/libghosttyxTests/ActionHandlingTests.swift
+++ b/Tests/libghosttyxTests/ActionHandlingTests.swift
@@ -5,6 +5,7 @@ import libghostty
 @MainActor
 final class ActionHandlingTests: XCTestCase {
 
+    @MainActor
     private class MockDelegate: TerminalViewDelegate {
         var mouseVisibility: Bool?
         var secureInputEnabled: Bool?

--- a/Tests/libghosttyxTests/ActionHandlingTests.swift
+++ b/Tests/libghosttyxTests/ActionHandlingTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import libghostty
+@testable import libghosttyx
+
+@MainActor
+final class ActionHandlingTests: XCTestCase {
+
+    private class MockDelegate: TerminalViewDelegate {
+        var mouseVisibility: Bool?
+        var secureInputEnabled: Bool?
+        var sizeLimitArgs: (minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32)?
+        var initialSizeArgs: (cols: UInt32, rows: UInt32)?
+        var progressArgs: (state: ghostty_action_progress_report_state_e, progress: Int8)?
+        var rendererHealth: ghostty_action_renderer_health_e?
+
+        func mouseVisibilityChanged(source: TerminalView, visible: Bool) {
+            mouseVisibility = visible
+        }
+        func secureInputChanged(source: TerminalView, enabled: Bool) {
+            secureInputEnabled = enabled
+        }
+        func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32) {
+            sizeLimitArgs = (minCols, minRows, maxCols, maxRows)
+        }
+        func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32) {
+            initialSizeArgs = (cols, rows)
+        }
+        func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8) {
+            progressArgs = (state, progress)
+        }
+        func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e) {
+            rendererHealth = health
+        }
+    }
+
+    private var view: TerminalView!
+    private var mock: MockDelegate!
+
+    override func setUp() {
+        super.setUp()
+        view = TerminalView(frame: .zero)
+        mock = MockDelegate()
+        view.delegate = mock
+    }
+
+    override func tearDown() {
+        view = nil
+        mock = nil
+        super.tearDown()
+    }
+
+    func testMouseVisibilityHideNotifiesDelegate() {
+        view.handleAction(.mouseVisibility(GHOSTTY_MOUSE_HIDDEN))
+        XCTAssertEqual(mock.mouseVisibility, false)
+    }
+
+    func testMouseVisibilityShowNotifiesDelegate() {
+        view.handleAction(.mouseVisibility(GHOSTTY_MOUSE_VISIBLE))
+        XCTAssertEqual(mock.mouseVisibility, true)
+    }
+
+    func testSecureInputOnNotifiesDelegate() {
+        view.handleAction(.secureInput(GHOSTTY_SECURE_INPUT_ON))
+        XCTAssertEqual(mock.secureInputEnabled, true)
+    }
+
+    func testSecureInputOffNotifiesDelegate() {
+        view.handleAction(.secureInput(GHOSTTY_SECURE_INPUT_OFF))
+        XCTAssertEqual(mock.secureInputEnabled, false)
+    }
+
+    func testSizeLimitNotifiesDelegate() {
+        view.handleAction(.sizeLimit(minWidth: 10, minHeight: 5, maxWidth: 300, maxHeight: 100))
+        XCTAssertEqual(mock.sizeLimitArgs?.minCols, 10)
+        XCTAssertEqual(mock.sizeLimitArgs?.minRows, 5)
+        XCTAssertEqual(mock.sizeLimitArgs?.maxCols, 300)
+        XCTAssertEqual(mock.sizeLimitArgs?.maxRows, 100)
+    }
+
+    func testInitialSizeNotifiesDelegate() {
+        view.handleAction(.initialSize(width: 80, height: 24))
+        XCTAssertEqual(mock.initialSizeArgs?.cols, 80)
+        XCTAssertEqual(mock.initialSizeArgs?.rows, 24)
+    }
+
+    func testProgressReportNotifiesDelegate() {
+        view.handleAction(.progressReport(state: GHOSTTY_PROGRESS_STATE_SET, progress: 42))
+        XCTAssertEqual(mock.progressArgs?.state, GHOSTTY_PROGRESS_STATE_SET)
+        XCTAssertEqual(mock.progressArgs?.progress, 42)
+    }
+
+    func testRendererHealthNotifiesDelegate() {
+        view.handleAction(.rendererHealth(GHOSTTY_RENDERER_HEALTH_UNHEALTHY))
+        XCTAssertEqual(mock.rendererHealth, GHOSTTY_RENDERER_HEALTH_UNHEALTHY)
+    }
+}

--- a/docs/superpowers/plans/2026-04-19-action-handling.md
+++ b/docs/superpowers/plans/2026-04-19-action-handling.md
@@ -1,0 +1,300 @@
+# Action Handling Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix six action types that `GhosttyCallbackBridge` claims as handled but `TerminalView.handleAction` silently discards, by adding delegate callbacks, built-in `NSCursor` behavior for mouse visibility, and a `#if DEBUG` log for future gaps.
+
+**Architecture:** Each action gets a new `TerminalViewDelegate` protocol method (with a no-op default so existing host apps don't break) and a matching `case` branch in `handleAction`. `mouseVisibility` additionally calls `NSCursor.hide()`/`unhide()` directly in `TerminalView` before firing the delegate, matching the existing pattern for `mouseShape`/`updateCursor`. The bridge requires no changes.
+
+**Tech Stack:** Swift, AppKit (`NSCursor`), `os` framework (`os_log`), XCTest
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `Sources/libghosttyx/Views/TerminalViewDelegate.swift` | Add 6 protocol methods + 6 default no-op implementations |
+| `Sources/libghosttyx/Views/TerminalView.swift` | Add `import os`, 6 `case` branches in `handleAction`, `#if DEBUG` log in `default` |
+| `Tests/libghosttyxTests/ActionHandlingTests.swift` | Create — `MockDelegate` + 8 XCTest methods |
+
+---
+
+## Task 1: Add delegate protocol methods and write failing tests
+
+**Files:**
+- Modify: `Sources/libghosttyx/Views/TerminalViewDelegate.swift`
+- Create: `Tests/libghosttyxTests/ActionHandlingTests.swift`
+
+- [ ] **Step 1: Add 6 methods to the `TerminalViewDelegate` protocol**
+
+Open `Sources/libghosttyx/Views/TerminalViewDelegate.swift`. Add these six declarations inside the `public protocol TerminalViewDelegate: AnyObject` block, after the existing `colorChanged` declaration on line 50:
+
+```swift
+    /// Called when the terminal requests the mouse cursor be shown or hidden.
+    func mouseVisibilityChanged(source: TerminalView, visible: Bool)
+
+    /// Called when secure input mode changes (e.g. a password prompt via sudo).
+    func secureInputChanged(source: TerminalView, enabled: Bool)
+
+    /// Called when Ghostty sets size constraints for the terminal.
+    func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32)
+
+    /// Called when Ghostty requests an initial terminal size.
+    func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32)
+
+    /// Called when a foreground command reports progress.
+    func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8)
+
+    /// Called when the GPU renderer health changes.
+    func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e)
+```
+
+- [ ] **Step 2: Add 6 no-op default implementations**
+
+In the same file, add these to the `public extension TerminalViewDelegate` block at the bottom, after the existing `colorChanged` default:
+
+```swift
+    func mouseVisibilityChanged(source: TerminalView, visible: Bool) {}
+    func secureInputChanged(source: TerminalView, enabled: Bool) {}
+    func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32) {}
+    func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32) {}
+    func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8) {}
+    func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e) {}
+```
+
+- [ ] **Step 3: Verify the delegate file compiles**
+
+```bash
+swift build 2>&1 | grep -E "error:|warning:|Build complete"
+```
+
+Expected: `Build complete!` with no errors. If there are errors, fix them before continuing.
+
+- [ ] **Step 4: Create the test file with the mock delegate and all 8 tests**
+
+Create `Tests/libghosttyxTests/ActionHandlingTests.swift` with this content:
+
+```swift
+import XCTest
+import libghostty
+@testable import libghosttyx
+
+@MainActor
+final class ActionHandlingTests: XCTestCase {
+
+    private class MockDelegate: TerminalViewDelegate {
+        var mouseVisibility: Bool?
+        var secureInputEnabled: Bool?
+        var sizeLimitArgs: (minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32)?
+        var initialSizeArgs: (cols: UInt32, rows: UInt32)?
+        var progressArgs: (state: ghostty_action_progress_report_state_e, progress: Int8)?
+        var rendererHealth: ghostty_action_renderer_health_e?
+
+        func mouseVisibilityChanged(source: TerminalView, visible: Bool) {
+            mouseVisibility = visible
+        }
+        func secureInputChanged(source: TerminalView, enabled: Bool) {
+            secureInputEnabled = enabled
+        }
+        func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32) {
+            sizeLimitArgs = (minCols, minRows, maxCols, maxRows)
+        }
+        func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32) {
+            initialSizeArgs = (cols, rows)
+        }
+        func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8) {
+            progressArgs = (state, progress)
+        }
+        func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e) {
+            rendererHealth = health
+        }
+    }
+
+    private var view: TerminalView!
+    private var mock: MockDelegate!
+
+    override func setUp() {
+        super.setUp()
+        view = TerminalView(frame: .zero)
+        mock = MockDelegate()
+        view.delegate = mock
+    }
+
+    override func tearDown() {
+        view = nil
+        mock = nil
+        super.tearDown()
+    }
+
+    func testMouseVisibilityHideNotifiesDelegate() {
+        view.handleAction(.mouseVisibility(GHOSTTY_MOUSE_HIDDEN))
+        XCTAssertEqual(mock.mouseVisibility, false)
+    }
+
+    func testMouseVisibilityShowNotifiesDelegate() {
+        view.handleAction(.mouseVisibility(GHOSTTY_MOUSE_VISIBLE))
+        XCTAssertEqual(mock.mouseVisibility, true)
+    }
+
+    func testSecureInputOnNotifiesDelegate() {
+        view.handleAction(.secureInput(GHOSTTY_SECURE_INPUT_ON))
+        XCTAssertEqual(mock.secureInputEnabled, true)
+    }
+
+    func testSecureInputOffNotifiesDelegate() {
+        view.handleAction(.secureInput(GHOSTTY_SECURE_INPUT_OFF))
+        XCTAssertEqual(mock.secureInputEnabled, false)
+    }
+
+    func testSizeLimitNotifiesDelegate() {
+        view.handleAction(.sizeLimit(minWidth: 10, minHeight: 5, maxWidth: 300, maxHeight: 100))
+        XCTAssertEqual(mock.sizeLimitArgs?.minCols, 10)
+        XCTAssertEqual(mock.sizeLimitArgs?.minRows, 5)
+        XCTAssertEqual(mock.sizeLimitArgs?.maxCols, 300)
+        XCTAssertEqual(mock.sizeLimitArgs?.maxRows, 100)
+    }
+
+    func testInitialSizeNotifiesDelegate() {
+        view.handleAction(.initialSize(width: 80, height: 24))
+        XCTAssertEqual(mock.initialSizeArgs?.cols, 80)
+        XCTAssertEqual(mock.initialSizeArgs?.rows, 24)
+    }
+
+    func testProgressReportNotifiesDelegate() {
+        view.handleAction(.progressReport(state: GHOSTTY_PROGRESS_STATE_SET, progress: 42))
+        XCTAssertEqual(mock.progressArgs?.state, GHOSTTY_PROGRESS_STATE_SET)
+        XCTAssertEqual(mock.progressArgs?.progress, 42)
+    }
+
+    func testRendererHealthNotifiesDelegate() {
+        view.handleAction(.rendererHealth(GHOSTTY_RENDERER_HEALTH_UNHEALTHY))
+        XCTAssertEqual(mock.rendererHealth, GHOSTTY_RENDERER_HEALTH_UNHEALTHY)
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to confirm failures**
+
+```bash
+swift test --filter ActionHandlingTests 2>&1 | tail -20
+```
+
+Expected: All 8 tests **fail** because `handleAction` doesn't call the delegate methods yet. You should see output like:
+```
+Test Case 'ActionHandlingTests.testMouseVisibilityHideNotifiesDelegate' failed
+XCTAssertEqual failed: ("nil") is not equal to ("Optional(false)")
+```
+
+If instead you see compile errors, fix them before continuing.
+
+- [ ] **Step 6: Commit the failing tests and delegate protocol**
+
+```bash
+git add Sources/libghosttyx/Views/TerminalViewDelegate.swift Tests/libghosttyxTests/ActionHandlingTests.swift
+git commit -m "test(actions): add failing tests for 6 unhandled action types"
+```
+
+---
+
+## Task 2: Implement the `handleAction` cases and debug logging
+
+**Files:**
+- Modify: `Sources/libghosttyx/Views/TerminalView.swift`
+
+- [ ] **Step 1: Add `import os` to TerminalView.swift**
+
+Open `Sources/libghosttyx/Views/TerminalView.swift`. The file currently starts with:
+
+```swift
+import AppKit
+import libghostty
+```
+
+Change it to:
+
+```swift
+import AppKit
+import libghostty
+import os
+```
+
+- [ ] **Step 2: Add the 6 case branches to `handleAction`**
+
+In `TerminalView.swift`, find the `handleAction` method. It currently ends with:
+
+```swift
+    case .mouseOverLink(let url):
+      currentHoverLink = url
+      delegate?.mouseOverLink(source: self, url: url)
+
+    default:
+      break
+    }
+  }
+```
+
+Replace that entire closing section with:
+
+```swift
+    case .mouseOverLink(let url):
+      currentHoverLink = url
+      delegate?.mouseOverLink(source: self, url: url)
+
+    case .mouseVisibility(let visibility):
+      let visible = visibility == GHOSTTY_MOUSE_VISIBLE
+      if visible { NSCursor.unhide() } else { NSCursor.hide() }
+      delegate?.mouseVisibilityChanged(source: self, visible: visible)
+
+    case .secureInput(let state):
+      delegate?.secureInputChanged(source: self, enabled: state == GHOSTTY_SECURE_INPUT_ON)
+
+    case .sizeLimit(let minW, let minH, let maxW, let maxH):
+      delegate?.sizeLimitChanged(source: self, minCols: minW, minRows: minH, maxCols: maxW, maxRows: maxH)
+
+    case .initialSize(let w, let h):
+      delegate?.initialSizeRequested(source: self, cols: w, rows: h)
+
+    case .progressReport(let state, let progress):
+      delegate?.progressReported(source: self, state: state, progress: progress)
+
+    case .rendererHealth(let health):
+      delegate?.rendererHealthChanged(source: self, health: health)
+
+    default:
+      #if DEBUG
+      os_log(.debug, "TerminalView: unhandled action %{public}@", String(describing: action))
+      #endif
+      break
+    }
+  }
+```
+
+- [ ] **Step 3: Run tests to confirm all 8 pass**
+
+```bash
+swift test --filter ActionHandlingTests 2>&1 | tail -20
+```
+
+Expected output:
+```
+Test Suite 'ActionHandlingTests' passed
+Executed 8 tests, with 0 failures (0 unexpected) in X.XXX seconds
+```
+
+If any tests fail, read the failure message carefully — it will tell you which assertion failed and with what value. Fix the corresponding `case` branch and re-run.
+
+- [ ] **Step 4: Run the full test suite to confirm no regressions**
+
+```bash
+swift test 2>&1 | tail -10
+```
+
+Expected: All tests pass with 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/libghosttyx/Views/TerminalView.swift
+git commit -m "feat(actions): handle mouseVisibility, secureInput, sizeLimit, initialSize, progressReport, rendererHealth"
+```

--- a/docs/superpowers/specs/2026-04-19-action-handling-design.md
+++ b/docs/superpowers/specs/2026-04-19-action-handling-design.md
@@ -1,0 +1,122 @@
+# Action Handling Fix — Design Spec
+
+**Issue:** [#6 — Several action types claimed as handled but silently dropped](https://github.com/sjungling/libghosttyx/issues/6)
+**Date:** 2026-04-19
+**Branch:** light-bronze-charm
+
+---
+
+## Problem
+
+`GhosttyCallbackBridge.actionCallback` returns `true` (handled) for six action types that `TerminalView.handleAction` silently discards via `default: break`. Ghostty believes these are handled; they are not.
+
+**Affected actions:**
+- `GHOSTTY_ACTION_MOUSE_VISIBILITY` — cursor show/hide on typing
+- `GHOSTTY_ACTION_SECURE_INPUT` — password prompt mode
+- `GHOSTTY_ACTION_SIZE_LIMIT` — min/max terminal size constraints
+- `GHOSTTY_ACTION_INITIAL_SIZE` — preferred startup size
+- `GHOSTTY_ACTION_PROGRESS_REPORT` — command progress indicator
+- `GHOSTTY_ACTION_RENDERER_HEALTH` — GPU renderer status
+
+`mouseVisibility` and `secureInput` have direct user-visible consequences. The rest affect host app behavior.
+
+---
+
+## Approach
+
+**Approach C:** Handle all 6 with delegate callbacks + built-in behavior where appropriate + debug logging for future gaps.
+
+- `TerminalView` handles `mouseVisibility` internally (calls `NSCursor.hide()`/`unhide()`) and fires the delegate, matching the existing pattern used by `mouseShape`/`updateCursor`.
+- All 6 actions fire new delegate methods with no-op defaults so existing host apps are unaffected.
+- `default: break` in `handleAction` gains a `#if DEBUG` `os_log` so future unhandled actions surface during development.
+- `GhosttyCallbackBridge` requires no changes — the bridge already returns `true` for these actions, which is correct once they are genuinely handled.
+
+---
+
+## Design
+
+### 1. `TerminalViewDelegate` — 6 new methods
+
+All added to the protocol with no-op default implementations in the protocol extension. No breaking changes to existing adopters.
+
+```swift
+func mouseVisibilityChanged(source: TerminalView, visible: Bool)
+func secureInputChanged(source: TerminalView, enabled: Bool)
+func sizeLimitChanged(source: TerminalView, minCols: UInt32, minRows: UInt32, maxCols: UInt32, maxRows: UInt32)
+func initialSizeRequested(source: TerminalView, cols: UInt32, rows: UInt32)
+func progressReported(source: TerminalView, state: ghostty_action_progress_report_state_e, progress: Int8)
+func rendererHealthChanged(source: TerminalView, health: ghostty_action_renderer_health_e)
+```
+
+### 2. `TerminalView.handleAction` — 6 new case branches
+
+```swift
+case .mouseVisibility(let visibility):
+    let visible = visibility == GHOSTTY_MOUSE_VISIBILITY_VISIBLE
+    if visible { NSCursor.unhide() } else { NSCursor.hide() }
+    delegate?.mouseVisibilityChanged(source: self, visible: visible)
+
+case .secureInput(let state):
+    delegate?.secureInputChanged(source: self, enabled: state == GHOSTTY_SECURE_INPUT_ON)
+
+case .sizeLimit(let minW, let minH, let maxW, let maxH):
+    delegate?.sizeLimitChanged(source: self, minCols: minW, minRows: minH, maxCols: maxW, maxRows: maxH)
+
+case .initialSize(let w, let h):
+    delegate?.initialSizeRequested(source: self, cols: w, rows: h)
+
+case .progressReport(let state, let progress):
+    delegate?.progressReported(source: self, state: state, progress: progress)
+
+case .rendererHealth(let health):
+    delegate?.rendererHealthChanged(source: self, health: health)
+
+default:
+    #if DEBUG
+    os_log(.debug, "TerminalView: unhandled action %{public}@", String(describing: action))
+    #endif
+    break
+```
+
+**Note on `NSCursor.hide()`:** This is a global push/pop balanced API. Ghostty manages the protocol and sends matching pairs — we translate the signal directly without tracking local state.
+
+### 3. `GhosttyCallbackBridge` — no changes
+
+The bridge already lists all 6 actions in its `return true` switch. Once `handleAction` actually handles them, the bridge is correct as-is.
+
+### 4. Tests — `ActionHandlingTests.swift`
+
+New file at `Tests/libghosttyxTests/ActionHandlingTests.swift`.
+
+Uses `@testable import libghosttyx` (same as existing tests) to access `internal` `handleAction`. A `MockDelegate` class records which callbacks fired and their argument values.
+
+Tests:
+- `testMouseVisibilityHideNotifiesDelegate`
+- `testMouseVisibilityShowNotifiesDelegate`
+- `testSecureInputOnNotifiesDelegate`
+- `testSecureInputOffNotifiesDelegate`
+- `testSizeLimitNotifiesDelegate`
+- `testInitialSizeNotifiesDelegate`
+- `testProgressReportNotifiesDelegate`
+- `testRendererHealthNotifiesDelegate`
+
+AppKit side effects (`NSCursor.hide()`) are not tested — they require a real display and follow the same deliberately-avoided pattern as the rest of the test suite.
+
+---
+
+## File Summary
+
+| File | Change |
+|------|--------|
+| `Sources/libghosttyx/Views/TerminalViewDelegate.swift` | Add 6 delegate methods + default no-ops |
+| `Sources/libghosttyx/Views/TerminalView.swift` | Add 6 `case` branches + `#if DEBUG` log in `default` |
+| `Sources/libghosttyx/Core/GhosttyCallbackBridge.swift` | No changes |
+| `Tests/libghosttyxTests/ActionHandlingTests.swift` | New file, 8 tests |
+
+---
+
+## Non-Goals
+
+- Window-level enforcement of `sizeLimit` — delegated to host app, not implemented in `TerminalView`
+- Dock progress bar for `progressReport` — delegated to host app
+- Persistent `isSecureInput` state property on `TerminalView` — not needed; delegate fires on change


### PR DESCRIPTION
## Summary

- Adds 6 new `TerminalViewDelegate` methods (`mouseVisibilityChanged`, `secureInputChanged`, `sizeLimitChanged`, `initialSizeRequested`, `progressReported`, `rendererHealthChanged`) with no-op defaults so existing host apps are unaffected
- Wires all 6 into `TerminalView.handleAction`, replacing the silent `default: break` — `mouseVisibility` additionally calls `NSCursor.hide()`/`unhide()` directly, matching the pattern used by `mouseShape`/`updateCursor`
- Adds `NSCursor.unhide()` to the `viewDidMoveToWindow` nil-window teardown path to prevent a process-wide cursor hide leak when the view is removed while the cursor is hidden
- Adds a `#if DEBUG` `os_log` in the `default` branch so future unhandled actions surface immediately during development

## Test Plan

- [ ] All 16 tests pass (`swift test`)
- [ ] 8 new tests in `ActionHandlingTests` cover all 6 actions (including both ON/OFF states for `secureInput` and both visibility states for `mouseVisibility`)
- [ ] Manually verify mouse cursor hides/shows during typing in a terminal session
- [ ] Manually verify cursor is restored when `TerminalView` is removed from its window