### PR TITLE
fix: xcframework checksum mismatch in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // --- Remote binary configuration (updated by CI on release) ---
 let xcframeworkURL =
   "https://github.com/sjungling/libghosttyx/releases/download/v0.3.13/libghostty.xcframework.zip"
-let xcframeworkChecksum = "ed431b428d2b90e4b1139eeb6b017ba40a75a1863c4c8c58887936b216a6f5ec"
+let xcframeworkChecksum = "e98c329eb13491503a8999ee19e813b809eb82cb8ff9c4603010e5ce5494be70"
 
 // Use local xcframework if present (local development), otherwise fetch from GitHub Releases
 let useLocal = FileManager.default.fileExists(


### PR DESCRIPTION
## Summary

- Corrects `xcframeworkChecksum` in `Package.swift` so it matches the SHA256 of the `v0.3.13` release asset currently referenced by `xcframeworkURL`.
- Old value: `ed431b428d2b90e4b1139eeb6b017ba40a75a1863c4c8c58887936b216a6f5ec`
- New value: `e98c329eb13491503a8999ee19e813b809eb82cb8ff9c4603010e5ce5494be70`

Without this, SPM rejects the package for every downstream consumer:

```
error: checksum of downloaded artifact of binary target 'libghostty'
(e98c329e...) does not match checksum specified by the manifest (ed431b42...)
```

Fixes #15.

## Test plan

- [x] Verified the new checksum with `curl -sL <asset-url> | shasum -a 256`
- [x] Verified the new checksum with `swift package compute-checksum` on the downloaded asset
- [ ] Tag a new release (`v0.3.16`) after merge so downstream consumers can pick up the fix