### PR TITLE
ci(release): fix Package.swift URL update + verify SHA matches published asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to release (e.g., v0.3.18)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,9 +15,24 @@ jobs:
   release:
     runs-on: macos-15
     steps:
-      - name: Checkout
+      - name: Validate version input
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.version }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$TAG' — expected vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          if gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists. Bump the version instead of retrying."
+            exit 1
+          fi
+
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
+          ref: main
           submodules: recursive
           fetch-depth: 0
 
@@ -48,52 +66,48 @@ jobs:
 
       - name: Update Package.swift
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.version }}
           CHECKSUM: ${{ steps.package.outputs.checksum }}
           REPO: ${{ github.repository }}
         run: |
-          python3 <<'PY'
-          import os, re, sys
-          asset_url = f"https://github.com/{os.environ['REPO']}/releases/download/{os.environ['TAG']}/libghostty.xcframework.zip"
-          checksum = os.environ['CHECKSUM']
-          content = open('Package.swift').read()
-          content, url_n = re.subn(
-              r'let\s+xcframeworkURL\s*=\s*"[^"]*"',
-              f'let xcframeworkURL = "{asset_url}"',
-              content,
-              count=1,
-          )
-          content, sum_n = re.subn(
-              r'let\s+xcframeworkChecksum\s*=\s*"[^"]*"',
-              f'let xcframeworkChecksum = "{checksum}"',
-              content,
-              count=1,
-          )
-          if url_n != 1 or sum_n != 1:
-              sys.exit(f"expected 1 replacement each; got url={url_n} checksum={sum_n}")
-          open('Package.swift', 'w').write(content)
-          print(f"URL:      {asset_url}")
-          print(f"Checksum: {checksum}")
-          PY
+          asset_url="https://github.com/$REPO/releases/download/$TAG/libghostty.xcframework.zip"
+          # Anchor sed on trailing `// libghosttyx-*` comments. See Package.swift
+          # header — anchors must stay on the same line as the value literal.
+          sed -i '' -E "s|^.*// libghosttyx-url\$|let xcframeworkURL = \"$asset_url\"  // libghosttyx-url|" Package.swift
+          sed -i '' -E "s|^.*// libghosttyx-checksum\$|let xcframeworkChecksum = \"$CHECKSUM\"  // libghosttyx-checksum|" Package.swift
+
+          if ! grep -qF "\"$asset_url\"  // libghosttyx-url" Package.swift; then
+            echo "::error::Failed to update xcframeworkURL — anchor '// libghosttyx-url' not found"
+            grep -n 'libghosttyx-' Package.swift || true
+            exit 1
+          fi
+          if ! grep -qF "\"$CHECKSUM\"  // libghosttyx-checksum" Package.swift; then
+            echo "::error::Failed to update xcframeworkChecksum — anchor '// libghosttyx-checksum' not found"
+            grep -n 'libghosttyx-' Package.swift || true
+            exit 1
+          fi
+          echo "URL:      $asset_url"
+          echo "Checksum: $CHECKSUM"
           git diff Package.swift
 
-      - name: Update tag with Package.swift
+      - name: Commit, tag, and push
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout main
           git add Package.swift
-          git commit -m "chore: update Package.swift for $TAG release"
-          git tag -f "$TAG"
+          git commit -m "chore: release $TAG"
+          # Tag is created fresh on the just-committed release commit; never
+          # force-pushed. If this push fails, the release is aborted cleanly.
+          git tag "$TAG"
           git push origin main
-          git push --force origin "$TAG"
+          git push origin "$TAG"
 
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.version }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists — uploading asset with --clobber"
@@ -108,7 +122,7 @@ jobs:
       - name: Verify published release matches Package.swift
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.version }}
           CHECKSUM: ${{ steps.package.outputs.checksum }}
           REPO: ${{ github.repository }}
         run: |
@@ -136,12 +150,12 @@ jobs:
           fi
           if ! grep -qF "\"$asset_url\"" Package.swift; then
             echo "::error::Package.swift does not reference $asset_url"
-            grep -nE 'xcframeworkURL|xcframeworkChecksum' Package.swift
+            grep -nE 'libghosttyx-' Package.swift || true
             exit 1
           fi
           if ! grep -qF "\"$CHECKSUM\"" Package.swift; then
             echo "::error::Package.swift does not reference checksum $CHECKSUM"
-            grep -nE 'xcframeworkURL|xcframeworkChecksum' Package.swift
+            grep -nE 'libghosttyx-' Package.swift || true
             exit 1
           fi
           echo "Release asset SHA and Package.swift both match — $TAG is publishable"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,31 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
           CHECKSUM: ${{ steps.package.outputs.checksum }}
+          REPO: ${{ github.repository }}
         run: |
-          repo_url="https://github.com/${{ github.repository }}"
-          asset_url="$repo_url/releases/download/$TAG/libghostty.xcframework.zip"
-          sed -i '' "s|^let xcframeworkURL = .*|let xcframeworkURL = \"$asset_url\"|" Package.swift
-          sed -i '' "s|^let xcframeworkChecksum = .*|let xcframeworkChecksum = \"$CHECKSUM\"|" Package.swift
-          echo "URL:      $asset_url"
-          echo "Checksum: $CHECKSUM"
+          python3 <<'PY'
+          import os, re, sys
+          asset_url = f"https://github.com/{os.environ['REPO']}/releases/download/{os.environ['TAG']}/libghostty.xcframework.zip"
+          checksum = os.environ['CHECKSUM']
+          content = open('Package.swift').read()
+          content, url_n = re.subn(
+              r'let\s+xcframeworkURL\s*=\s*"[^"]*"',
+              f'let xcframeworkURL = "{asset_url}"',
+              content,
+              count=1,
+          )
+          content, sum_n = re.subn(
+              r'let\s+xcframeworkChecksum\s*=\s*"[^"]*"',
+              f'let xcframeworkChecksum = "{checksum}"',
+              content,
+              count=1,
+          )
+          if url_n != 1 or sum_n != 1:
+              sys.exit(f"expected 1 replacement each; got url={url_n} checksum={sum_n}")
+          open('Package.swift', 'w').write(content)
+          print(f"URL:      {asset_url}")
+          print(f"Checksum: {checksum}")
+          PY
           git diff Package.swift
 
       - name: Update tag with Package.swift
@@ -72,12 +90,58 @@ jobs:
           git push origin main
           git push --force origin "$TAG"
 
-      - name: Create GitHub release
+      - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
-          gh release create "$TAG" \
-            Frameworks/libghostty.xcframework.zip \
-            --title "$TAG" \
-            --generate-notes
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — uploading asset with --clobber"
+            gh release upload "$TAG" Frameworks/libghostty.xcframework.zip --clobber
+          else
+            gh release create "$TAG" \
+              Frameworks/libghostty.xcframework.zip \
+              --title "$TAG" \
+              --generate-notes
+          fi
+
+      - name: Verify published release matches Package.swift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          CHECKSUM: ${{ steps.package.outputs.checksum }}
+          REPO: ${{ github.repository }}
+        run: |
+          asset_url="https://github.com/$REPO/releases/download/$TAG/libghostty.xcframework.zip"
+          echo "Verifying asset at $asset_url"
+          for i in 1 2 3 4 5; do
+            http_code=$(curl -sLo /tmp/asset.zip -w '%{http_code}' "$asset_url")
+            if [ "$http_code" = "200" ] && [ -s /tmp/asset.zip ]; then
+              break
+            fi
+            echo "Attempt $i: HTTP $http_code, retrying in 5s..."
+            rm -f /tmp/asset.zip
+            sleep 5
+          done
+          if [ ! -s /tmp/asset.zip ]; then
+            echo "::error::Could not download release asset from $asset_url"
+            exit 1
+          fi
+          downloaded_sha=$(shasum -a 256 /tmp/asset.zip | awk '{print $1}')
+          echo "Downloaded SHA: $downloaded_sha"
+          echo "Computed SHA:   $CHECKSUM"
+          if [ "$downloaded_sha" != "$CHECKSUM" ]; then
+            echo "::error::Downloaded asset SHA does not match computed checksum"
+            exit 1
+          fi
+          if ! grep -qF "\"$asset_url\"" Package.swift; then
+            echo "::error::Package.swift does not reference $asset_url"
+            grep -nE 'xcframeworkURL|xcframeworkChecksum' Package.swift
+            exit 1
+          fi
+          if ! grep -qF "\"$CHECKSUM\"" Package.swift; then
+            echo "::error::Package.swift does not reference checksum $CHECKSUM"
+            grep -nE 'xcframeworkURL|xcframeworkChecksum' Package.swift
+            exit 1
+          fi
+          echo "Release asset SHA and Package.swift both match — $TAG is publishable"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,21 @@ Use `GHOSTTY_DIR=/path/to/ghostty` to build against an external Ghostty checkout
 
 ## Releasing
 
-Releases are triggered by pushing a version tag (`git tag v0.2.0 && git push origin v0.2.0`). The GitHub Actions workflow builds the xcframework, updates Package.swift with the download URL and checksum, and creates a GitHub release.
+Releases are triggered **manually** via `workflow_dispatch`, not by pushing a tag. From the GitHub Actions UI (or `gh workflow run release.yml -f version=v0.3.18`), the workflow:
+
+1. Validates the version string and that the tag doesn't already exist
+2. Builds the xcframework from `main` and computes its SHA-256
+3. Rewrites `Package.swift` via sed anchored on the trailing `// libghosttyx-url` and `// libghosttyx-checksum` comments
+4. Commits `chore: release $TAG` to `main`, creates the tag **on that commit**, pushes both
+5. Creates the GitHub Release and uploads the xcframework zip
+6. Downloads the published asset back and asserts its SHA matches both the computed checksum and what's in `Package.swift` — the build fails loudly if anything drifts
+
+### Release rules (invariants)
+
+- **NEVER force-push tags.** Tags must point at the release commit from creation. The workflow creates the tag *after* the Package.swift update is committed; it never moves an existing tag. If a release needs to be redone, bump the patch version instead of retagging.
+- **NEVER hand-edit `xcframeworkURL` or `xcframeworkChecksum` in `Package.swift`.** CI owns those lines. The trailing `// libghosttyx-url` / `// libghosttyx-checksum` anchors must stay on the same line as their values — the release workflow's sed substitution finds them by those anchors.
+- **`Package.swift` carries `// swift-format-ignore-file`** to prevent formatters from rewrapping the anchor lines. Do not remove that directive.
+- **Broken releases stay broken.** If a published release's `Package.swift` and asset disagree, do not attempt to fix the existing tag — tag a new patch version.
 
 ## Updating Ghostty
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // --- Remote binary configuration (updated by CI on release) ---
 let xcframeworkURL =
   "https://github.com/sjungling/libghosttyx/releases/download/v0.3.13/libghostty.xcframework.zip"
-let xcframeworkChecksum = "ed431b428d2b90e4b1139eeb6b017ba40a75a1863c4c8c58887936b216a6f5ec"
+let xcframeworkChecksum = "e98c329eb13491503a8999ee19e813b809eb82cb8ff9c4603010e5ce5494be70"
 
 // Use local xcframework if present (local development), otherwise fetch from GitHub Releases
 let useLocal = FileManager.default.fileExists(

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,17 @@
 // swift-tools-version: 5.9
+// swift-format-ignore-file
+//
+// This manifest is rewritten by the release workflow. Do not reformat — the
+// trailing `// libghosttyx-url` and `// libghosttyx-checksum` anchors MUST
+// stay on the same line as their value literals for CI's sed substitution to
+// find them. If you edit this file, preserve those anchors exactly.
 
 import Foundation
 import PackageDescription
 
 // --- Remote binary configuration (updated by CI on release) ---
-let xcframeworkURL =
-  "https://github.com/sjungling/libghosttyx/releases/download/v0.3.13/libghostty.xcframework.zip"
-let xcframeworkChecksum = "e98c329eb13491503a8999ee19e813b809eb82cb8ff9c4603010e5ce5494be70"
+let xcframeworkURL = "https://github.com/sjungling/libghosttyx/releases/download/v0.3.13/libghostty.xcframework.zip"  // libghosttyx-url
+let xcframeworkChecksum = "e98c329eb13491503a8999ee19e813b809eb82cb8ff9c4603010e5ce5494be70"  // libghosttyx-checksum
 
 // Use local xcframework if present (local development), otherwise fetch from GitHub Releases
 let useLocal = FileManager.default.fileExists(


### PR DESCRIPTION
## Summary

Three fixes to `.github/workflows/release.yml` that together repair the root cause of #15 and prevent recurrence.

### 1. Robust Package.swift substitution

The previous step used:

```bash
sed -i '' "s|^let xcframeworkURL = .*|let xcframeworkURL = \"\$asset_url\"|" Package.swift
```

That regex only matches when the URL literal is on the same line as the `let` keyword. At some point swift-format wrapped the URL onto a continuation line, so the URL `sed` silently became a no-op on every release — while the checksum `sed` (still single-line) happily updated. The result: every release since the wrap has a Package.swift whose URL references a **different** release asset than the checksum was computed for. SPM rejects all of them.

Replaced with a Python regex using `\s+` so it matches whether the URL is wrapped or inline, and fails the job loudly if the expected replacement count isn't exactly 1.

### 2. Idempotent release publish

`gh release create` fails when the release already exists. v0.3.17 hit this — a release object had been manually created 40s before the tag push, so the workflow aborted on `Create GitHub release` after having already done the build, checksum, and tag force-push. Left the tag in a broken state with no asset at the expected URL.

Now: if the release exists, `gh release upload --clobber`. Otherwise, create it.

### 3. Post-publish verification

New step downloads the just-uploaded asset via its public URL, recomputes its SHA, and fails the build if any of the following don't match:
- Downloaded SHA vs. computed checksum
- Package.swift's URL line vs. the expected asset URL
- Package.swift's checksum line vs. the computed checksum

This is the safety net the workflow lacked — every broken release since v0.3.14 would have failed loudly here instead of silently shipping.

## Plan to verify

After merge, tag `v0.3.18`. The fixed workflow should produce a Package.swift with matching URL + checksum, and the new verification step proves it end-to-end. If anything drifts, the build fails rather than publishing.

Fixes #15 (root cause). v0.3.15, v0.3.16, and v0.3.17 remain broken on remote resolution — consumers should skip straight to v0.3.18.

## Test plan

- [x] Verified the new Python regex matches the current wrapped URL in `Package.swift`
- [ ] Merge, tag v0.3.18, confirm workflow succeeds end-to-end
- [ ] `curl -sL <v0.3.18 asset URL> | shasum -a 256` matches the checksum in Package.swift at v0.3.18
- [ ] URL in Package.swift at v0.3.18 points to v0.3.18 (not v0.3.13)